### PR TITLE
Update zilliqa release version to 6.4.2

### DIFF
--- a/Mining.md
+++ b/Mining.md
@@ -396,7 +396,7 @@ For hooking up several GPU rigs in the GPU cluster to a single CPU node, you wil
 8. Clone the Zilliqa repository and change directory to it:
 
       ```
-      cd ~/Desktop && git clone https://github.com/Zilliqa/Zilliqa.git Zilliqa && cd Zilliqa && git checkout v6.4.1
+      cd ~/Desktop && git clone https://github.com/Zilliqa/Zilliqa.git Zilliqa && cd Zilliqa && git checkout v6.4.2
       ```
 
 9. Find out your Zilliqa directory path again and write it down:


### PR DESCRIPTION
## Description:
Update zilliqa release version from `6.4.1` to `6.4.2` in mining readme.